### PR TITLE
[Bug-Fix]Changed the variable undefined_variable to result

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ class WebCrawler:
         if results:
             print("Search results:")
             for result in results:
-                print(f"- {undefined_variable}")
+                print(f"- {result}")
         else:
             print("No results found.")
 


### PR DESCRIPTION
### Problem:
`undefined_variable` in the `print_results()` function is not defined. This can cause a `NameError` when running the code.

### Fix:

Changed the variable from `undefined_variable` to `result`, which is defined in the `for each` loop, which would result in printing out each result on each line.