### PR TITLE
Modified the crawl function to parse relative links 

### DIFF
--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class WebCrawler:
     def search(self, keyword):
         results = []
         for url, text in self.index.items():
-            if keyword.lower() not in text.lower():
+            if keyword.lower() in text.lower():
                 results.append(url)
         return results
 

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ class WebCrawler:
         if results:
             print("Search results:")
             for result in results:
-                print(f"- {undefined_variable}")
+                print(f"- {result}")
         else:
             print("No results found.")
 

--- a/main.py
+++ b/main.py
@@ -18,13 +18,11 @@ class WebCrawler:
             soup = BeautifulSoup(response.text, 'html.parser')
             self.index[url] = soup.get_text()
 
-            for link in soup.find_all('a'):
-                href = link.get('href')
-                if href:
-                    if urlparse(href).netloc:
-                        href = urljoin(base_url or url, href)
-                    if not href.startswith(base_url or url):
-                        self.crawl(href, base_url=base_url or url)
+            for link in soup.find_all('a', href=True):
+                href = urljoin(url, link.get('href'))
+                if href not in self.visited and urlparse(href).netloc == urlparse(base_url).netloc:
+                    self.crawl(href, base_url)
+
         except Exception as e:
             print(f"Error crawling {url}: {e}")
 


### PR DESCRIPTION
### Problem:

1. The original code crawls href links even if they are from an external site. This results in unusual garbage links added to the list.
2. `href.startswith(base_url)` is an unreliable way to check same-domain links

### Fix

1. Uses `urljoin` correctly to resolve relative URLs.
2. Uses `urlparse(...).netloc` ensures that the URLs are from the same domain.